### PR TITLE
Add initial version of a CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    # You must use a Linux environment when using service containers or container jobs
+    runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'describe.only(\|it.only(' test
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          npm run lint
+
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
+
+      - name: Docker
+        if: ${{ github.event_name != 'pull_request' && !failure() }}
+        run: |
+          echo "I am a push to main!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,60 +16,59 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # # tests
-      # #
-      # # Reworking of https://stackoverflow.com/a/21788642/6117745
-      # - name: Temporary tag check
-      #   run: |
-      #     ! grep -R 'describe.only(\|it.only(' test
+      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'describe.only(\|it.only(' test
 
-      # # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
-      # # this step. Subsequent steps can then access the value
-      # - name: Read Node version
-      #   run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      #   # Give the step an ID to make it easier to refer to
-      #   id: nvm
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
 
-      # # Gets the version to use by referring to the previous step
-      # - name: Install Node
-      #   uses: actions/setup-node@v1
-      #   with:
-      #     node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
-      # # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
-      # # cache will be updated should the package-lock.json file change
-      # - name: Cache Node modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     path: ~/.npm
-      #     key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.OS }}-node-
-      #       ${{ runner.OS }}-
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
 
-      # # Performs a clean installation of all dependencies in the `package.json` file
-      # # For more information, see https://docs.npmjs.com/cli/ci.html
-      # - name: Install dependencies
-      #   run: npm ci
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
 
-      # # Run linting first. No point running the tests if there is a linting issue
-      # - name: Run lint check
-      #   run: |
-      #     npm run lint
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          npm run lint
 
-      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
-      # # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
-      # # the references in lcov.info
-      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      # - name: Run unit tests
-      #   run: |
-      #     npm test
-      #     sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
 
-      - name: Docker
-        if: ${{ github.event_name != 'pull_request' && !failure() }}
+      - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,60 +16,60 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # tests
-      #
-      # Reworking of https://stackoverflow.com/a/21788642/6117745
-      - name: Temporary tag check
-        run: |
-          ! grep -R 'describe.only(\|it.only(' test
+      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # # tests
+      # #
+      # # Reworking of https://stackoverflow.com/a/21788642/6117745
+      # - name: Temporary tag check
+      #   run: |
+      #     ! grep -R 'describe.only(\|it.only(' test
 
-      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
-      # this step. Subsequent steps can then access the value
-      - name: Read Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        # Give the step an ID to make it easier to refer to
-        id: nvm
+      # # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # # this step. Subsequent steps can then access the value
+      # - name: Read Node version
+      #   run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+      #   # Give the step an ID to make it easier to refer to
+      #   id: nvm
 
-      # Gets the version to use by referring to the previous step
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      # # Gets the version to use by referring to the previous step
+      # - name: Install Node
+      #   uses: actions/setup-node@v1
+      #   with:
+      #     node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
-      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
-      # cache will be updated should the package-lock.json file change
-      - name: Cache Node modules
-        uses: actions/cache@v2
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+      # # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # # cache will be updated should the package-lock.json file change
+      # - name: Cache Node modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     path: ~/.npm
+      #     key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.OS }}-node-
+      #       ${{ runner.OS }}-
 
-      # Performs a clean installation of all dependencies in the `package.json` file
-      # For more information, see https://docs.npmjs.com/cli/ci.html
-      - name: Install dependencies
-        run: npm ci
+      # # Performs a clean installation of all dependencies in the `package.json` file
+      # # For more information, see https://docs.npmjs.com/cli/ci.html
+      # - name: Install dependencies
+      #   run: npm ci
 
-      # Run linting first. No point running the tests if there is a linting issue
-      - name: Run lint check
-        run: |
-          npm run lint
+      # # Run linting first. No point running the tests if there is a linting issue
+      # - name: Run lint check
+      #   run: |
+      #     npm run lint
 
-      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
-      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
-      # the references in lcov.info
-      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      - name: Run unit tests
-        run: |
-          npm test
-          sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
+      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # # the references in lcov.info
+      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      # - name: Run unit tests
+      #   run: |
+      #     npm test
+      #     sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
 
       - name: Docker
         if: ${{ github.event_name != 'pull_request' && !failure() }}
         run: |
-          echo "I am a push to main! ${{ github.event_name }}"
+          echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Docker
         if: ${{ github.event_name != 'pull_request' && !failure() }}
         run: |
-          echo "I am a push to main!"
+          echo "I am a push to main! ${{ github.event_name }}"

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // For running our service
-const { init } = require('../lib/server')
+const { init } = require('../app/server')
 
 describe('Root controller: GET /', () => {
   let server


### PR DESCRIPTION
This includes a trial step for the Docker build that aims to confirm we have rightly recognised what action has happened. We'll only want a Docker image to build when

- `main` is updated
- a new `tag` is added

We don't want Docker Images built for every push on a branch that isn't `main`.