### PR TITLE
Add integration with SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
       PORT: 3000
 
     steps:
+      - name: Event info
+        run: |
+          echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
+
       # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -69,6 +73,8 @@ jobs:
           npm test
           sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
 
-      - name: Event info
-        run: |
-          echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,24 @@
+sonar.projectKey=Cruikshanks_gha-docker-demo
+sonar.organization=cruikshanks
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=gha-docker-demo
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/Cruikshanks/gha-docker-demo
+sonar.links.ci=https://github.com/Cruikshanks/gha-docker-demo/actions
+sonar.links.scm=https://github.com/Cruikshanks/gha-docker-demo
+sonar.links.issue=https://github.com/Cruikshanks/gha-docker-demo/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# SonarCloud seems to have little intelligence when it comes to code coverage.
+# Quite simply if it sees a code file, it checks it against our coverage report
+# and if not found flags it as uncovered. This also effects the overall coverage
+# score. In our case this means SonarCloud is flagging everything under test/
+# as lacking code coverage!
+sonar.sources=./app,./config
+sonar.tests=./test
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,3 +22,6 @@ sonar.tests=./test
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+# Ensure SonarCloud knows where to pick up test coverage stats
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
This is what we use on the SROC Charging Module API and we want to investigate how this step works in conjunction with whatever we plan to do with Docker.

We're exploring the other [GitHub action workflow events](https://docs.github.com/en/actions/reference/events-that-trigger-workflows) so if we make a change to how and when things get kicked off we want to know SonarCloud will still work.