### PR TITLE
Split CI workflow into separate jobs

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,0 +1,20 @@
+name: ANALYSE
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["PR"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Event info
+        run: |
+          echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -4,17 +4,19 @@ name: ANALYSE
 # access to secrets
 on:
   workflow_run:
-    workflows: ["PR"]
-    types:
-      - completed
+    workflows: ["PR", "CI"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
     steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
+          echo "I was triggered by ${{ github.event.workflow_run.event }} which was ${{ GITHUB_REF#refs/heads/}}"

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -4,7 +4,9 @@ name: ANALYSE
 # access to secrets
 on:
   workflow_run:
-    workflows: ["PR", "CI"]
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   build:
@@ -19,4 +21,4 @@ jobs:
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
-          echo "I was triggered by ${{ github.event.workflow_run.event }} which was ${{ GITHUB_REF#refs/heads/}}"
+          echo "I was triggered by ${{ github.event.workflow_run.event }} which was ${{ github.event.workflow_run.conclusion }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
       PORT: 3000
 
     steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
-
-      # # Downloads a copy of the code in your repository before running CI tests
-      # - name: Checkout repository
-      #   uses: actions/checkout@v2
-      #   with:
-      #     fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
       # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
       # # tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,67 +14,67 @@ jobs:
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
 
-      # Downloads a copy of the code in your repository before running CI tests
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+      # # Downloads a copy of the code in your repository before running CI tests
+      # - name: Checkout repository
+      #   uses: actions/checkout@v2
+      #   with:
+      #     fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # tests
-      #
-      # Reworking of https://stackoverflow.com/a/21788642/6117745
-      - name: Temporary tag check
-        run: |
-          ! grep -R 'describe.only(\|it.only(' test
+      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # # tests
+      # #
+      # # Reworking of https://stackoverflow.com/a/21788642/6117745
+      # - name: Temporary tag check
+      #   run: |
+      #     ! grep -R 'describe.only(\|it.only(' test
 
-      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
-      # this step. Subsequent steps can then access the value
-      - name: Read Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        # Give the step an ID to make it easier to refer to
-        id: nvm
+      # # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # # this step. Subsequent steps can then access the value
+      # - name: Read Node version
+      #   run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+      #   # Give the step an ID to make it easier to refer to
+      #   id: nvm
 
-      # Gets the version to use by referring to the previous step
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      # # Gets the version to use by referring to the previous step
+      # - name: Install Node
+      #   uses: actions/setup-node@v1
+      #   with:
+      #     node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
-      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
-      # cache will be updated should the package-lock.json file change
-      - name: Cache Node modules
-        uses: actions/cache@v2
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+      # # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # # cache will be updated should the package-lock.json file change
+      # - name: Cache Node modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     path: ~/.npm
+      #     key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.OS }}-node-
+      #       ${{ runner.OS }}-
 
-      # Performs a clean installation of all dependencies in the `package.json` file
-      # For more information, see https://docs.npmjs.com/cli/ci.html
-      - name: Install dependencies
-        run: npm ci
+      # # Performs a clean installation of all dependencies in the `package.json` file
+      # # For more information, see https://docs.npmjs.com/cli/ci.html
+      # - name: Install dependencies
+      #   run: npm ci
 
-      # Run linting first. No point running the tests if there is a linting issue
-      - name: Run lint check
-        run: |
-          npm run lint
+      # # Run linting first. No point running the tests if there is a linting issue
+      # - name: Run lint check
+      #   run: |
+      #     npm run lint
 
-      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
-      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
-      # the references in lcov.info
-      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      - name: Run unit tests
-        run: |
-          npm test
-          sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
+      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # # the references in lcov.info
+      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      # - name: Run unit tests
+      #   run: |
+      #     npm test
+      #     sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      # - name: SonarCloud Scan
+      #   uses: SonarSource/sonarcloud-github-action@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,61 +20,61 @@ jobs:
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"
 
-      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # # tests
-      # #
-      # # Reworking of https://stackoverflow.com/a/21788642/6117745
-      # - name: Temporary tag check
-      #   run: |
-      #     ! grep -R 'describe.only(\|it.only(' test
+      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'describe.only(\|it.only(' test
 
-      # # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
-      # # this step. Subsequent steps can then access the value
-      # - name: Read Node version
-      #   run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      #   # Give the step an ID to make it easier to refer to
-      #   id: nvm
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
 
-      # # Gets the version to use by referring to the previous step
-      # - name: Install Node
-      #   uses: actions/setup-node@v1
-      #   with:
-      #     node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
-      # # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
-      # # cache will be updated should the package-lock.json file change
-      # - name: Cache Node modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     path: ~/.npm
-      #     key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.OS }}-node-
-      #       ${{ runner.OS }}-
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
 
-      # # Performs a clean installation of all dependencies in the `package.json` file
-      # # For more information, see https://docs.npmjs.com/cli/ci.html
-      # - name: Install dependencies
-      #   run: npm ci
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
 
-      # # Run linting first. No point running the tests if there is a linting issue
-      # - name: Run lint check
-      #   run: |
-      #     npm run lint
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          npm run lint
 
-      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
-      # # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
-      # # the references in lcov.info
-      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      # - name: Run unit tests
-      #   run: |
-      #     npm test
-      #     sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's/\/home\/runner\/work\/gha-docker-demo\/gha-docker-demo\//\/github\/workspace\//g' coverage/lcov.info
 
-      # - name: SonarCloud Scan
-      #   uses: SonarSource/sonarcloud-github-action@master
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: PR
+
+# read-only repo token
+# no access to secrets
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+
+    steps:
+      - name: Event info
+        run: |
+          echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,12 @@ jobs:
       PORT: 3000
 
     steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} to ${GITHUB_REF#refs/heads/}"


### PR DESCRIPTION
Based on our reading it looks like we could create a Docker workflow that would be triggered by the [GitHub Action `workflow_run` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run).

This means we can start to break up the actions and trigger them at specific points. Another benefit of doing this is it also looks like the [recommended way](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) to run a build when changes come in but still access repo secrets.

Our Dependabot PR's started failing some time ago because they could no longer access the `SONAR_TOKEN` in a repo's secrets.

For reference, [GitHub locked this down](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) to prevent abuse by folks raising malicious PR's against public repos.