### PR TITLE
Update docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,33 +4,58 @@ name: DOCKER
 # access to secrets
 on:
   push:
-    branches:
-      - "!*"
-    tags:
-      - "v*"
-  workflow_run:
-    workflows: ["CI"]
-    branches:
-      - main
-    types:
-      - completed
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.event.workflow_run.event, 'pull_request') }}
     steps:
-      # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
       - name: Extract branch name
         run: |
           echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
 
+      - name: Extract git commit hash
+        run: |
+          echo "GIT_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} on ${{ env.BRANCH }}"
-          echo "I was triggered by ${{ github.event.workflow_run.event }} which was ${{ github.event.workflow_run.conclusion }}"
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We're scrapping the idea of trying to trigger the docker workflow after the CI one as it's overcomplicating things.

Instead we've taken what GitHub generates via the UI when you say you want to build and push a Docker image to a registry with some minor tweaks. We'll use that as our starter-for-ten whilst we work out how everything works.