### PR TITLE
Add build args to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
 
-      - name: Extract git commit hash
-        run: |
-          echo "GIT_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-
       - name: Event info
         run: |
           echo "I am a ${{ github.event_name }} on ${{ env.BRANCH }}"
@@ -50,12 +46,20 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set build args
+        run: |
+          echo "GIT_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args: |
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
+            DOCKER_TAG=${{ env.DOCKER_TAG }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
When we build our SROC Charging Module API image we depend on 2 build args being passed in. These are then 'baked' into the image so that the API can return the git sha and docker tag of the version of the API running. We use this info for diagnostic purposes.

This change to our demo project we hope will replicate setting and using these build args when the image is built by GitHub actions.