### PR TITLE
Add push to DockerHub to workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # Login against DockerHub
+      # https://github.com/docker/login-action
+      - name: Log into Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Login against a Docker registry
       # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into GH Container Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -50,3 +58,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Push Image to DockerHub
+        uses: akhilerm/tag-push-action@v1.1.0
+        with:
+          src: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          dst: |
+            docker.io/cruikshanks/${{ env.IMAGE_NAME }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}


### PR DESCRIPTION
Having applied what we have learnt here to [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) we then hit a blocker. For the [Defra Organisation](https://github.com/DEFRA) the default settings for packages is that they are private and that access needs to be explicit.

We're looking at container registry usage as an org but until 'there can be only one' there is a good chance we might need to support pushing to multiple registries.

So, this change updates the Docker workflow to push to both registries.